### PR TITLE
Update motorkit_dc_test.py

### DIFF
--- a/examples/motorkit_dc_test.py
+++ b/examples/motorkit_dc_test.py
@@ -11,13 +11,13 @@ while True:
     time.sleep(1)
 
     print("Speed up...")
-    for i in range(0, 100):
+    for i in range(0, 101):
         speed = i * 0.01
         kit.motor1.throttle = speed
         time.sleep(0.01)
 
     print("Slow down...")
-    for i in reversed(range(0, 100)):
+    for i in range(100, -1, -1):
         speed = i * 0.01
         kit.motor1.throttle = speed
         time.sleep(0.01)
@@ -27,13 +27,13 @@ while True:
     time.sleep(1)
 
     print("Speed up...")
-    for i in range(-100, 0):
+    for i in range(0, -101, -1):
         speed = i * 0.01
         kit.motor1.throttle = speed
         time.sleep(0.01)
 
     print("Slow down...")
-    for i in reversed(range(-100, 0)):
+    for i in range(-100, 1):
         speed = i * 0.01
         kit.motor1.throttle = speed
         time.sleep(0.01)


### PR DESCRIPTION
Here's the updated example code. It corrects the incompatibility with non-express boards and properly cycles through the entire motor throttle range from -1.0 to 0 to +1.0.